### PR TITLE
feat: support stereo processing

### DIFF
--- a/infer-web.py
+++ b/infer-web.py
@@ -942,7 +942,8 @@ with gr.Blocks(title="RVC WebUI") as app:
                         with gr.Row():
                             vc_output1 = gr.Textbox(label=i18n("输出信息"))
                             vc_output2 = gr.Audio(
-                                label=i18n("输出音频(右下角三个点,点了可以下载)")
+                                label=i18n("输出音频(右下角三个点,点了可以下载)"),
+                                type="numpy",
                             )
 
                         but0.click(


### PR DESCRIPTION
## Summary
- allow `load_audio` to optionally preserve stereo channels
- share detected pitch across channels for consistent stereo conversion
- explicitly enable stereo arrays in web UI output

## Testing
- `python3 -m py_compile infer/lib/audio.py infer/modules/vc/pipeline.py infer/modules/vc/modules.py infer-web.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897d39a59e4832c83e6ead4e62a2fd9